### PR TITLE
fix: remove deprecated draw_all function on colorbar

### DIFF
--- a/UtilityBelt/earthplot.py
+++ b/UtilityBelt/earthplot.py
@@ -258,7 +258,7 @@ def make_earthplot(trigtime, trigid, orbitdat, prompt=True, outdir=''):
     # McIlwain L
     artist = mcilwain_map(lon_range, lat_range, ax, saa_poly, alpha=0.5)
     cb = plt.colorbar(artist, label='McIlwain L', ax=ax, shrink=0.6, pad=0.05, orientation='horizontal')
-    cb.draw_all()
+
 
     if prompt:
         title = f'Earthplot from TLE (provisional)'


### PR DESCRIPTION
This pull request makes a minor change to the `make_earthplot` function in `UtilityBelt/earthplot.py` by removing the call to `cb.draw_all()`, which was previously used to explicitly redraw the colorbar. This simplifies the code and relies on matplotlib's default behavior for rendering colorbars.